### PR TITLE
[marctk] extract fields using an inclusive range or spec string

### DIFF
--- a/marctk/src/lib.rs
+++ b/marctk/src/lib.rs
@@ -13,5 +13,6 @@ pub use self::xml::MARCXML_XSI_NAMESPACE;
 
 pub mod binary;
 pub mod breaker;
+mod query;
 pub mod record;
 pub mod xml;

--- a/marctk/src/query.rs
+++ b/marctk/src/query.rs
@@ -1,0 +1,67 @@
+use std::ops::RangeInclusive;
+
+use crate::Field;
+
+pub struct Query {
+    pub field_filter: Box<dyn Fn(&&Field) -> bool>,
+}
+
+impl From<RangeInclusive<i64>> for Query {
+    fn from(range: RangeInclusive<i64>) -> Self {
+        Query {
+            field_filter: Box::new(move |f: &&Field| match f.tag().parse::<i64>() {
+                Ok(tag_number) => range.contains(&tag_number),
+                Err(_) => false,
+            }),
+        }
+    }
+}
+
+impl From<&str> for Query {
+    fn from(specification: &str) -> Self {
+        let spec = specification.to_owned();
+        Query {
+            field_filter: Box::new(move |f: &&Field| f.matches_spec(&spec)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Record;
+
+    #[test]
+    fn test_can_filter_by_inclusive_range() {
+        let query = Query::from(600..=699);
+        let record = Record::from_breaker(
+            r#"=600 10$aZhang, Heng, $d 78-139 $v Juvenile literature.
+=650 \0$aEarthquakes $v Juvenile literature.
+=955 \0$a1234"#,
+        )
+        .unwrap();
+        let filter = query.field_filter;
+        let mut filtered = record.fields().iter().filter(filter);
+        assert_eq!(filtered.next().unwrap().tag(), "600");
+        assert_eq!(filtered.next().unwrap().tag(), "650");
+        assert!(filtered.next().is_none());
+    }
+
+    #[test]
+    fn test_can_filter_by_string_slice() {
+        let query = Query::from("x50");
+        let record = Record::from_breaker(
+            r#"=150 \\$aLion
+=450 \\$aPanthera leo
+=550 \\$wg$aPanthera
+=953 \\$axx00$bec11"#,
+        )
+        .unwrap();
+        let filter = query.field_filter;
+        let mut filtered = record.fields().iter().filter(filter);
+        assert_eq!(filtered.next().unwrap().tag(), "150");
+        assert_eq!(filtered.next().unwrap().tag(), "450");
+        assert_eq!(filtered.next().unwrap().tag(), "550");
+        assert!(filtered.next().is_none());
+    }
+}

--- a/marctk/src/record.rs
+++ b/marctk/src/record.rs
@@ -686,6 +686,21 @@ impl Record {
         }
     }
 
+    /// Extract MARC fields using a range of tags or a specification
+    /// inspired by [ruby-marc](https://github.com/ruby-marc/ruby-marc/),
+    /// [SolrMarc](https://github.com/solrmarc/solrmarc/wiki/Basic-field-based-extraction-specifications),
+    /// and [traject](https://github.com/traject/traject).
+    ///
+    /// # Specification syntax
+    ///
+    /// * A three-character tag will match any field that has that tag, for example `650` would
+    ///   only match fields with the tag `650`.
+    /// * The letter `x` (or upper case `X`) can be used as a wildcard, for example `2xx` would
+    ///   match any field with a tag that starts with the character `2`.
+    /// * Multiple specifications can be combined with a `:` between them, for example
+    ///   `4xx:52x:901` would match any field with tag `901` or a tag that begins with
+    ///   `4` or `52`.
+    ///
     /// # Examples
     ///
     /// ```
@@ -704,10 +719,15 @@ impl Record {
     /// let mut more_fields = record.extract_fields("9xx");
     /// assert_eq!(more_fields.next().unwrap().tag(), "955");
     /// assert!(more_fields.next().is_none());
+    ///
+    /// let mut you_can_combine_specs = record.extract_fields("600:9xx");
+    /// assert_eq!(you_can_combine_specs.next().unwrap().tag(), "600");
+    /// assert_eq!(you_can_combine_specs.next().unwrap().tag(), "955");
+    /// assert!(you_can_combine_specs.next().is_none());
     /// ```
     pub fn extract_fields(
         &self,
-        query: impl Into<crate::query::Query>,
+        query: impl Into<crate::query::FieldQuery>,
     ) -> impl Iterator<Item = &Field> {
         self.fields().iter().filter(query.into().field_filter)
     }

--- a/marctk/src/record.rs
+++ b/marctk/src/record.rs
@@ -409,6 +409,33 @@ impl Field {
 
         removed
     }
+
+    /// # Examples
+    ///
+    /// ```
+    /// use marctk::Field;
+    /// let field = Field::new("505").unwrap();
+    /// assert!(field.matches_spec("505"));
+    /// assert!(field.matches_spec("5xx"));
+    /// assert!(field.matches_spec("50x"));
+    /// assert!(field.matches_spec("5x5"));
+    /// assert!(field.matches_spec("x05"));
+    /// assert!(field.matches_spec("5XX"));
+    ///
+    /// assert!(!field.matches_spec("6xx"));
+    /// assert!(!field.matches_spec("LDR"));
+    /// assert!(!field.matches_spec("invalid spec"));
+    /// ```
+    pub fn matches_spec(&self, spec: &str) -> bool {
+        if spec.len() != 3 {
+            return false;
+        };
+        spec.chars()
+            .zip(self.tag().chars())
+            .all(|(spec_char, tag_char)| {
+                spec_char.to_ascii_lowercase() == 'x' || spec_char == tag_char
+            })
+    }
 }
 
 /// A MARC record with leader, control fields, and data fields.
@@ -657,5 +684,31 @@ impl Record {
         while let Some(pos) = self.fields.iter().position(|f| f.tag() == tag) {
             self.fields.remove(pos);
         }
+    }
+
+    /// # Examples
+    ///
+    /// ```
+    /// use marctk::Record;
+    /// let record = Record::from_breaker(
+    ///     r#"=600 10$aZhang, Heng, $d 78-139 $v Juvenile literature.
+    /// =650 \0$aEarthquakes $v Juvenile literature.
+    /// =955 \0$a1234"#
+    /// ).unwrap();
+    ///
+    /// let mut some_fields = record.extract_fields(600..=699);
+    /// assert_eq!(some_fields.next().unwrap().tag(), "600");
+    /// assert_eq!(some_fields.next().unwrap().tag(), "650");
+    /// assert!(some_fields.next().is_none());
+    ///
+    /// let mut more_fields = record.extract_fields("9xx");
+    /// assert_eq!(more_fields.next().unwrap().tag(), "955");
+    /// assert!(more_fields.next().is_none());
+    /// ```
+    pub fn extract_fields(
+        &self,
+        query: impl Into<crate::query::Query>,
+    ) -> impl Iterator<Item = &Field> {
+        self.fields().iter().filter(query.into().field_filter)
     }
 }


### PR DESCRIPTION
This allows you to do things like the following:

```
record.extract_fields(600..=699) # returns an iterator through all your 6xx fields
record.extract_fields("6xx") # ditto
record.extract_fields("65x") # only take fields that start with 65, like 650 or 655
record.extract_fields("x50") # only take fields that end with 50, like 150 or 450
```

It returns an iterator, so if you only need, say, the first 2 `020` fields, you can `record.extract_fields("020").take(2)`, and it will be lazily evaluated to potentially save a few field checks.


Helps with #21