### PR TITLE
[marctk] Add optional convenience methods for Marc21 bibliographic records

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Build
       run: cargo build --all
     - name: Run tests
-      run: cargo test --all
+      run: cargo test --all --all-features
 
   clippy:
     runs-on: ubuntu-latest

--- a/marctk/Cargo.toml
+++ b/marctk/Cargo.toml
@@ -18,3 +18,15 @@ xml-rs = "0.8.25"
 name = "marc-converter"
 path = "src/bin/marc-converter.rs"
 
+[features]
+marc21_bibliographic = []
+
+# Note: to view the documentation as it would appear on
+# docs.rs (with optional features associated with their
+# feature flags), you can:
+# ```
+# cargo install --locked cargo-docs-rs
+# cargo +nightly docs-rs --open -p marctk
+# ```
+[package.metadata.docs.rs]
+all-features = true

--- a/marctk/src/lib.rs
+++ b/marctk/src/lib.rs
@@ -2,6 +2,13 @@
 
 //! Tools for managing MARC21 records and reading/writing records as
 //! binary, XML, and MARC breaker.
+//!
+//! # Optional features
+//!
+//! - **marc21_bibliographic**: convenience methods to get
+//!   commonly used data from a MARC21 bibliographic record
+
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 pub use self::record::Controlfield;
 pub use self::record::Field;

--- a/marctk/src/record.rs
+++ b/marctk/src/record.rs
@@ -920,4 +920,66 @@ impl Record {
             .map(|sf| sf.content().to_owned())
             .collect()
     }
+
+    /// # Examples
+    ///
+    /// ```
+    /// use marctk::Record;
+    /// let record = Record::from_breaker(r#"=LDR 02322cam a2200445u  4500
+    ///=245 10$aRobot / $c Jan Pieńkowski.
+    ///=520 \\$aA robot family's everyday life is described and illustrated in a dutiful young robot's letter home inquiring how everyone is doing."#)
+    ///     .unwrap();
+    /// assert_eq!(record.main_title(), Some("Robot / ".to_string()));
+    /// ```
+    #[cfg(feature = "marc21_bibliographic")]
+    pub fn main_title(&self) -> Option<String> {
+        Some(
+            self.get_fields("245")
+                .first()?
+                .first_subfield("a")?
+                .content()
+                .to_owned(),
+        )
+    }
+
+    /// An alternative to [`get_fields`] that returns parallel 880 fields,
+    /// which are also known as
+    /// [alternate graphic representations](https://www.loc.gov/marc/bibliographic/bd880.html)
+    /// in the MARC21 standard.
+    ///
+    /// In records where catalogers have entered both the original script
+    /// of a language and a Romanized version, `get_parallel_fields` will
+    /// return the original script, while `get_fields` will return the
+    /// Romanized version.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use marctk::Record;
+    /// let record = Record::from_breaker(r#"=LDR 02322cam a2200445u  4500
+    ///=100 1\$6880-01 $a Shukrī Tabrīzī, Shukr Allāh, $d 18th century, $e author.
+    ///=880 1\$6100-01/(3/r $a شکری تبریزی، شکرالله."#)
+    ///     .unwrap();
+    /// let original_script_fields = record.get_parallel_fields("100");
+    /// assert_eq!(original_script_fields.len(), 1);
+    /// let field = original_script_fields.first().unwrap();
+    /// assert_eq!(
+    ///     field.first_subfield("a").unwrap().content(),
+    ///     " شکری تبریزی، شکرالله."
+    /// );
+    /// ```
+    /// [`get_fields`]: crate::Record::get_fields
+    #[cfg(feature = "marc21_bibliographic")]
+    pub fn get_parallel_fields(&self, tag: &str) -> Vec<&Field> {
+        let parallel_field_matches = {
+            |field: &Field| match field.first_subfield("6") {
+                Some(subfield) => subfield.content().starts_with(tag),
+                None => false,
+            }
+        };
+        self.fields
+            .iter()
+            .filter(|f| f.tag() == "880" && parallel_field_matches(f))
+            .collect()
+    }
 }


### PR DESCRIPTION
This commit adds two new methods behind a feature flag named marc21_bibliographic (with the thought that future contributors might want to add separate convenience methods for, say, authority records or UNIMARC bibliographic records).

The `cargo test` invocation in CI is updated to run tests for all features.

We also enable the nightly doc_auto_cfg feature when docs.rs generates the marctk documentation, which provides nice feature flag badges in the documentation for any functionality that is behind a flag.

Closes #27 